### PR TITLE
ENG-207: check synonyms

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -52,6 +52,7 @@ pipeline:
     min_ngram: 1
     max_ngram: 4
   - name: rasa_plus.spaces.components.spaces_crf_entity_extractor.SpacesCRFEntityExtractor
+  - name: EntitySynonymMapper
   - name: DIETClassifier
     epochs: 100
     ranking_length: 0

--- a/main/domain.yml
+++ b/main/domain.yml
@@ -9,6 +9,7 @@ intents:
 
 entities:
   - amount-of-money
+  - machine-type
 
 responses:
   utter_greet:

--- a/main/nlu/training_data.yml
+++ b/main/nlu/training_data.yml
@@ -15,17 +15,18 @@ nlu:
     - stop, no
 - intent: bot_challenge
   examples: |
-    - you talk like a bot
-    - are you a machine?
+    - you talk like a [bot](machine-type)
+    - are you a [machine](machine-type)?
+    - are you an [AI](machine-type)?
     - you are a bot, aren't you?
     - am I just talking to a machine?
     - am I talking to a bot?
     - you talk like a machine
-    - am I talking to a human?
-    - am I talking to a person?
+    - am I talking to a [human](machine-type)?
+    - am I talking to a [person](machine-type)?
     - you sound a lot like a bot
     - are you a virtual assistant or a person?
-    - are you a human?
+    - are you a [human being](machine-type)?
     - can you tell me whether I am talking to a person?
 - intent: affirm
   examples: |
@@ -77,3 +78,14 @@ nlu:
     - good night
     - bye
     - catch you later
+
+- synonym: bot
+  examples: |
+    - assitant
+    - AI
+
+- synonym: person
+  examples: |
+    - person
+    - human
+    - human being

--- a/pay_cc/nlu/training_data.yml
+++ b/pay_cc/nlu/training_data.yml
@@ -10,6 +10,8 @@ nlu:
     - Pay off my credit card, please
     - I want to pay my card
     - I want to pay my [MasterCard](credit_card) bill
+    - I want to pay my [Master Card](credit_card) bill
+    - I want to pay my [MC](credit_card) bill
     - I guess it is. Since it's so much, let's pay off my credit
     - I want to pay $ [500](amount-of-money) on my [emblem](credit_card) credit card on Sunday
     - Please schedule  a payment towards my credit card for April 12th
@@ -24,6 +26,9 @@ nlu:
     - Can I schedule a payment towards my credit card for tomorrow?
     - i need to pay off my [emblm](credit_card) credit card
     - I want to pay my [iron bank](credit_card) bill
+    - I want to pay my [ironbank](credit_card) bill
+    - I want to pay my [Ibank](credit_card) bill
+    - I want to pay my [IB](credit_card) bill
     - pay a bill
     - i want to pay off my credit card
     - I want to pay [100](amount-of-money) dollars toward my [Emblem](credit_card) card, tomorrow
@@ -74,3 +79,14 @@ nlu:
     - My [Visa](credit_card) account
     - towards my [iron bank](credit_card) card
     - my [current balance](amount-of-money-description)
+
+- synonym: mastercard
+  examples: |
+    - master card
+    - MC
+
+- synonym: ironbank
+  examples: |
+    - iron bank
+    - IBank
+    - IB


### PR DESCRIPTION
Fixes https://rasahq.atlassian.net/browse/ENG-257

## Testing protocol
- checkout `spaces` branch and run `make install`
- checkout this branch in another directory
- run `RASA_PRO_LICENSE=... rasa train`
- run `RASA_PRO_LICENSE=... rasa shell --debug`
- talk to the bot, look at logs to verify that synonyms are mapped to the same entity name

## Test cases
- Synonyms in the main space are extracted and mapped properly ✅ 
- Synonyms in a specialised spaces' entry intent are extracted and mapped properly ✅ 
- Synonyms in a specialised spaces' (any) intent are extracted and mapped properly ✅ 