### PR TITLE
Add quantity sample to the training data

### DIFF
--- a/investment/nlu/training_data.yml
+++ b/investment/nlu/training_data.yml
@@ -47,3 +47,4 @@ nlu:
     - [F](ticker)
     - [AAPL](ticker)
     - [160](amount-of-money)$
+    - [20](quantity) shares


### PR DESCRIPTION
To support conversations like this:

```
Your input ->  I want to buy stocks                                                                                                                                                                                       
What's the ticker symbol of the stock you want to buy?
Your input ->  TSLA                                                                                                                                                                                                       
How many shares do you want to buy of TSLA?
Your input ->  10 shares                                                                                                                                                                                                  
? Would you like to place an order for 10 shares of TSLA for 10 USD each? 1: Yes (/affirm)                                                                                                                                
I have placed your order!
Is there anything else I can do for you?
```

Without this sample, it asks for amount of shares again and again